### PR TITLE
해외 앨범 3단계 구조 구현 (국가 → 지역 → 사진 목록)

### DIFF
--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -6,7 +6,7 @@
       <GradleProjectSettings>
         <option name="testRunner" value="CHOOSE_PER_TEST" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
-        <option name="gradleJvm" value="#GRADLE_LOCAL_JAVA_HOME" />
+        <option name="gradleJvm" value="#JAVA_HOME" />
         <option name="modules">
           <set>
             <option value="$PROJECT_DIR$" />

--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -1,6 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
   <component name="ExternalStorageConfigurationManager" enabled="true" />
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="jbr-21" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_21" default="true" project-jdk-name="21" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="ProjectType">

--- a/app/src/main/java/com/example/wakey/data/local/Photo.java
+++ b/app/src/main/java/com/example/wakey/data/local/Photo.java
@@ -46,6 +46,9 @@ public class Photo {
     @ColumnInfo(name = "caption")
     public String caption;
 
+    @ColumnInfo(name = "country")
+    public String country; // 예: "일본", "미국"
+
     // ✅ List<Pair<String, Float>>로 변경
     @TypeConverters(Converters.class)
     @ColumnInfo(name = "detectedObjectPairs")
@@ -98,10 +101,6 @@ public class Photo {
     public void setEmbeddingVector(float[] vector) {
         this.embeddingVector = vector;
         this.embeddingVectorStr = vectorToString(vector);
-    }
-
-    public String getEmbeddingVectorStr() {
-        return embeddingVectorStr;
     }
 
     public float[] getEmbeddingVector() {

--- a/app/src/main/java/com/example/wakey/data/local/PhotoDao.java
+++ b/app/src/main/java/com/example/wakey/data/local/PhotoDao.java
@@ -69,4 +69,11 @@ public interface PhotoDao {
     // 예측된 객체 결과와 함께 저장된 사진 조회
     @Query("SELECT * FROM Photo WHERE filePath = :filePath LIMIT 1")
     Photo getPhotoWithDetectedPairs(String filePath);
+
+    @Query("SELECT DISTINCT country FROM Photo WHERE country IS NOT NULL")
+    List<String> getAllCountries();
+
+    @Query("SELECT * FROM Photo WHERE country = :country")
+    List<Photo> getPhotosByCountry(String country);
+
 }

--- a/app/src/main/java/com/example/wakey/data/repository/ImageRepository.java
+++ b/app/src/main/java/com/example/wakey/data/repository/ImageRepository.java
@@ -146,6 +146,7 @@ public class ImageRepository {
 
                 String locationDo = null, locationSi = null, locationGu = null, locationStreet = null;
                 Double latitude = null, longitude = null;
+                String countryName = null;
 
                 double[] latLng = ExifUtil.getLatLngFromExif(FileUtils.getPath(context, uri));
                 if (latLng != null) {
@@ -163,6 +164,8 @@ public class ImageRepository {
                         String thoroughfare = addr.getThoroughfare() != null ? addr.getThoroughfare() : "";
                         String featureName = addr.getFeatureName() != null ? addr.getFeatureName() : "";
                         locationStreet = (thoroughfare + " " + featureName).trim();
+
+                        countryName = addr.getCountryName();
                     }
                 }
 
@@ -178,13 +181,13 @@ public class ImageRepository {
                 photo.latitude = latitude;
                 photo.longitude = longitude;
                 photo.setDetectedObjectPairs(detectedPairs);  // ✅ 핵심 변경점
+                photo.country = countryName;
 
                 float[] embeddingVector = meta.getEmbeddingVector();
                 if (embeddingVector != null) {
                     photo.setEmbeddingVector(embeddingVector);
                 }
 
-                Log.d("ImageRepository", "🧬 저장 전 벡터 길이: " + (embeddingVector != null ? embeddingVector.length : 0));
                 Log.d("ImageRepository", "📥 저장될 객체 정보: " + detectedPairs);
 
                 db.photoDao().insertPhoto(photo);

--- a/app/src/main/java/com/example/wakey/ui/album/overseas/OverseasCountryActivity.java
+++ b/app/src/main/java/com/example/wakey/ui/album/overseas/OverseasCountryActivity.java
@@ -1,0 +1,104 @@
+package com.example.wakey.ui.album.overseas;
+
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.Log;
+import android.view.View;
+import android.widget.ProgressBar;
+import android.widget.TextView;
+
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.recyclerview.widget.GridLayoutManager;
+import androidx.recyclerview.widget.RecyclerView;
+
+import com.example.wakey.R;
+import com.example.wakey.data.local.Photo;
+import com.example.wakey.data.repository.PhotoRepository;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+
+public class OverseasCountryActivity extends AppCompatActivity {
+    private static final String TAG = "OverseasCountryActivity";
+
+    private RecyclerView countryRecyclerView;
+    private OverseasLocationAdapter countryAdapter;
+    private ProgressBar loadingSpinner;
+    private TextView emptyTextView;
+
+    private PhotoRepository photoRepository;
+    private List<OverseasFragment.OverseasLocationItem> countryItems = new ArrayList<>();
+
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        setContentView(R.layout.activity_overseas_country);
+
+        photoRepository = new PhotoRepository(this);
+        initViews();
+        loadCountryData();
+    }
+
+    private void initViews() {
+        countryRecyclerView = findViewById(R.id.recyclerViewCountries);
+        countryRecyclerView.setLayoutManager(new GridLayoutManager(this, 2));
+
+        loadingSpinner = findViewById(R.id.loadingSpinner);
+        emptyTextView = findViewById(R.id.emptyTextView);
+
+        countryAdapter = new OverseasLocationAdapter(countryItems, item -> {
+            Intent intent = new Intent(OverseasCountryActivity.this, OverseasRegionActivity.class);
+            intent.putExtra("REGION_NAME", item.getName());
+            intent.putExtra("REGION_ORIGINAL_NAME", item.getOriginalName());
+            startActivity(intent);
+        });
+
+        countryRecyclerView.setAdapter(countryAdapter);
+    }
+
+    private void loadCountryData() {
+        loadingSpinner.setVisibility(View.VISIBLE);
+        photoRepository.getOverseasPhotos().thenAccept(countryMap -> {
+            List<OverseasFragment.OverseasLocationItem> items = new ArrayList<>();
+
+            for (Map.Entry<String, List<Photo>> entry : countryMap.entrySet()) {
+                String country = entry.getKey();
+                List<Photo> photos = entry.getValue();
+
+                if (photos.isEmpty()) continue;
+
+                String thumbnailPath = photos.get(0).filePath;
+
+                OverseasFragment.OverseasLocationItem item = new OverseasFragment.OverseasLocationItem(
+                        country, country, thumbnailPath, photos.size()
+                );
+                items.add(item);
+            }
+
+            Collections.sort(items, Comparator.comparing(OverseasFragment.OverseasLocationItem::getName));
+
+            runOnUiThread(() -> {
+                loadingSpinner.setVisibility(View.GONE);
+                if (items.isEmpty()) {
+                    emptyTextView.setVisibility(View.VISIBLE);
+                } else {
+                    emptyTextView.setVisibility(View.GONE);
+                    countryItems.clear();
+                    countryItems.addAll(items);
+                    countryAdapter.notifyDataSetChanged();
+                }
+            });
+        }).exceptionally(e -> {
+            Log.e(TAG, "Error loading country data", e);
+            runOnUiThread(() -> {
+                loadingSpinner.setVisibility(View.GONE);
+                emptyTextView.setVisibility(View.VISIBLE);
+                emptyTextView.setText("데이터를 불러오지 못했습니다.");
+            });
+            return null;
+        });
+    }
+}

--- a/app/src/main/res/layout/activity_overseas_country.xml
+++ b/app/src/main/res/layout/activity_overseas_country.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8"?>
+<androidx.constraintlayout.widget.ConstraintLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
+    android:layout_width="match_parent"
+    android:layout_height="match_parent"
+    android:padding="16dp"
+    android:background="#FFFFFF">
+
+    <ProgressBar
+        android:id="@+id/loadingSpinner"
+        android:layout_width="48dp"
+        android:layout_height="48dp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <TextView
+        android:id="@+id/emptyTextView"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:text="해외 사진이 없습니다"
+        android:textColor="#888888"
+        android:textSize="16sp"
+        android:visibility="gone"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/recyclerViewCountries"
+        android:layout_width="0dp"
+        android:layout_height="0dp"
+        android:clipToPadding="false"
+        android:paddingBottom="16dp"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintStart_toStartOf="parent"
+        app:layout_constraintEnd_toEndOf="parent" />
+
+</androidx.constraintlayout.widget.ConstraintLayout>


### PR DESCRIPTION
- OverseasRegionActivity에서 국가 선택 시 해당 국가 내 지역(locationDo) 기준으로 사진 그룹화
- Photo.country 필드를 기준으로 정확한 필터링 적용
- 국가/지역 간 구분 명확화 및 UI 흐름 정리
- 기존 국내 앨범 구조와 동일한 방식으로 해외도 지역별 앨범 정렬 가능하게 개선